### PR TITLE
Remove output file before starting the merge Fixes #1

### DIFF
--- a/merger.js
+++ b/merger.js
@@ -20,8 +20,10 @@ var mainFile = opt.options['main-file'] ? path.join(workDir, opt.options['main-f
 var mainIsProcessed = false;
 var processOnce = []; //Array holds files which had '#pragma once'
 
-//Wipe file to start
-fs.writeFileSync(outputFile, "");
+// Remove file before starting
+if (fs.existsSync(outputFile)) {
+    fs.unlinkSync(outputFile);
+}
 
 
 if (mainFile) {


### PR DESCRIPTION
Fixes #1
This will prevent output cpp file from being included in itself.
Instead of wiping the content of the file, I deleted the file.
This could have been done with exclusion, but I think this is simple and fits well with the original approach.