### PR TITLE
Enabled `exclude-dir` to allow specifying multiple directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-
+.idea/

--- a/merger.js
+++ b/merger.js
@@ -19,6 +19,7 @@ var excludeDir = opt.options['exclude-dir'] ? opt.options['exclude-dir'].split(/
 var mainFile = opt.options['main-file'] ? path.join(workDir, opt.options['main-file']): null;
 var mainIsProcessed = false;
 var processOnce = []; //Array holds files which had '#pragma once'
+var libraryIncludes = new Set(); // Array holds the names of libraries that have already been included.
 
 //Wipe file to start
 fs.writeFileSync(outputFile, "");
@@ -84,6 +85,12 @@ function processFile(file, include) {
         processFile(includedFile, true);
       } else if (line.indexOf("#pragma once") >= 0) {
         processOnce.push(file);
+      } else if (line.indexOf("#include <") >= 0) {
+          let includedFile = line.substring(line.indexOf("<") + 1, line.lastIndexOf(">"));
+          if (!libraryIncludes.has(includedFile)) {
+              libraryIncludes.add(includedFile);
+              fs.appendFileSync(outputFile, line + "\n");
+          }
       } else {
         fs.appendFileSync(outputFile, line + "\n");
       }

--- a/merger.js
+++ b/merger.js
@@ -15,7 +15,7 @@ const opt = require('node-getopt').create([
 
 var workDir = opt.options['working-dir'] ? opt.options['working-dir'] : '.';
 var outputFile = opt.options['output'] ? opt.options['output'] : 'merged';
-var excludeDir = opt.options['exclude-dir'] ? opt.options['exclude-dir'] : 'generated';
+var excludeDir = opt.options['exclude-dir'] ? opt.options['exclude-dir'].split(/[;,]/) : ['generated'];
 var mainFile = opt.options['main-file'] ? path.join(workDir, opt.options['main-file']): null;
 var mainIsProcessed = false;
 var processOnce = []; //Array holds files which had '#pragma once'
@@ -40,7 +40,7 @@ function processDir(dir)
     let node = nodes[i];
     let fullPath = path.join(dir, node);
     let stat = fs.statSync(fullPath);
-    if (stat.isDirectory() && path.basename(fullPath) != excludeDir) {
+    if (stat.isDirectory() && excludeDir.indexOf(path.basename(fullPath)) === -1) {
       processDir(fullPath);
     } else if (stat.isFile()) {
       processFile(fullPath, false);


### PR DESCRIPTION
I needed to specify more than one directory to ignore.  The following commit allows specifying multiple directories using either commas or semicolons as separators.  It provides the expected results locally.